### PR TITLE
Implement Session Tokens.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ class GooglePlacesSuggest extends React.Component {
 
     this.state = {
       focusedPredictionIndex: 0,
+      sessionToken: "",
       predictions: [],
       open: !!props.autocompletionRequest && props.autocompletionRequest.input,
     }
@@ -57,8 +58,11 @@ class GooglePlacesSuggest extends React.Component {
       },
       () => {
         this.hasFocus = false
-        this.geocodePrediction(suggest.description, result => {
+        this.placesDetails(suggest.place_id, result => {
           onSelectSuggest(result, suggest)
+        })
+        this.setState({
+          sessionToken: "",
         })
       }
     )
@@ -67,6 +71,11 @@ class GooglePlacesSuggest extends React.Component {
   updatePredictions(autocompletionRequest) {
     const {googleMaps} = this.props
     const autocompleteService = new googleMaps.places.AutocompleteService()
+    if (!this.state.sessionToken) {
+      this.setState({
+        sessionToken: new googleMaps.places.AutocompleteSessionToken(),
+      })
+    }
     if (!autocompletionRequest || !autocompletionRequest.input) {
       this.setState(
         {
@@ -79,7 +88,10 @@ class GooglePlacesSuggest extends React.Component {
     }
 
     autocompleteService.getPlacePredictions(
-      autocompletionRequest, // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
+      {
+        ...autocompletionRequest,
+        sessionToken: this.state.sessionToken,
+      }, // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
       (predictions, status) => {
         this.props.onStatusUpdate(status)
         if (!predictions) {
@@ -95,20 +107,27 @@ class GooglePlacesSuggest extends React.Component {
     )
   }
 
-  geocodePrediction(address, callback) {
+  placesDetails(placeId, callback) {
     const {googleMaps} = this.props
-    const geocoder = new googleMaps.Geocoder()
+    const map = new googleMaps.Map(document.createElement("map"))
 
-    geocoder.geocode({address}, (results, status) => {
-      if (status === googleMaps.GeocoderStatus.OK) {
-        if (results.length > 0) {
-          callback(results[0])
+    const placesService = new googleMaps.places.PlacesService(map)
+
+    placesService.getDetails(
+      {
+        placeId,
+        fields: ["geometry", "address_components", "types"],
+        sessionToken: this.state.sessionToken,
+      },
+      (result, status) => {
+        if (status === googleMaps.places.PlacesServiceStatus.OK) {
+          callback(result)
+        } else {
+          // eslint-disable-next-line
+          console.error("Places service error: " + status)
         }
-      } else {
-        // eslint-disable-next-line
-        console.error("Geocode error: " + status)
       }
-    })
+    )
   }
 
   handleKeyDown(e) {

--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,9 @@ class GooglePlacesSuggest extends React.Component {
 
     autocompleteService.getPlacePredictions(
       {
-        ...autocompletionRequest,
+        ...autocompletionRequest, // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
         sessionToken: this.state.sessionToken,
-      }, // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
+      },
       (predictions, status) => {
         this.props.onStatusUpdate(status)
         if (!predictions) {


### PR DESCRIPTION
## The Problem
The current implementation has two flaws:
1. Currently this component calls the Google Maps Places API on every user inputted keystroke. This results in several, separately billed, API calls which in large quantities can result in very large bills from Google.
2. This component also calls the Geocoding API on every user's autocomplete selection. This results in additional billed API calls, which in large quantities also results in significant billing from Google.

### The Solution to 1
This PR implements session based autocomplete. The [AutocompletionRequest](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service?hl=fr#AutocompletionRequest) allows us to pass in a [sessionToken](https://developers.google.com/maps/documentation/places/web-service/session-tokens).

> Place Autocomplete uses session tokens to group the query and selection phases of a user autocomplete search into a discrete session for billing purposes. The session begins when the user starts typing a query, and concludes when they select a place and a call to Place Details is made. Each session can have multiple autocomplete queries, followed by one place selection. The API key(s) used for each request within a session must belong to the same Google Cloud Console project. Once a session has concluded, the token is no longer valid; your app must generate a fresh token for each session. If the sessiontoken parameter is omitted, or if you reuse a session token, the session is charged as if no session token was provided (each request is billed separately).

I believe this would be a significant win for the google billing portion for consumers of this component.

As I understand it, a session begins with a user typing, and ends with the auto complete being selected from the list. Upon typing again, a new session token is generated. The advantages and benefits here should be quite clear: a potential significant reduction in API calls and billing from Google.

Additionally, consumers of this component no longer have to implement their own debouncing for user input, since it will all be billed together on one session token.

### The Solution to 2
This PR implements session based Places Details retrieval, through the [PlacesService](https://developers.google.com/maps/documentation/javascript/reference/places-service). We can utilize our existing `sessionToken` with a `getDetails` request through this service, and specify the `fields` that we want to retrieve. In the case of the existing functionality, the Geocoding appeared to be returning the following fields on the payload: `address_components`, `geometry`, `types`. By specifying those fields to the `getDetails` we can return a payload that looks identical to the current functionality, so there shouldn't be a large breaking change here. One caveat however, is `formatted_address`. This field appears to exist on the Geocoding result under `address_components` but no longer appears as a field from the `getDetails`. We _can_ include the `formatted_address` in the `getDetails` by specifying it on the `fields`, however I don't believe it would live under `address_components` any longer and would technically be a breaking change to anyone using `formatted_address` from the `address_components` property.

This `fields` data falls under the [Basic Data SKU](https://developers.google.com/maps/billing/gmp-billing?_ga=2.28109946.71994496.1616426981-2053028179.1590784861#basic-data) for a Places request and do not result in any additional charge.

This would also allow the component to easily accept a `fields` prop to address #46

