### PR TITLE
Fix details request.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,12 @@ class GooglePlacesSuggest extends React.Component {
     placesService.getDetails(
       {
         placeId,
-        fields: ["geometry", "address_components", "types"],
+        fields: [
+          "geometry",
+          "address_components",
+          "types",
+          "formatted_address",
+        ],
         sessionToken: this.state.sessionToken,
       },
       (result, status) => {


### PR DESCRIPTION
In my places details fix I incorrectly thought that `formatted_address` lived under `address_components`, however it does not. This adds the `formatted_address` to the places `getDetails` request, so the response payload now equally matches when we were calling the geolocation API.

Add formatted_address to the fields call for places getDetails.