### PR TITLE
fix(List): Pass props to CustomContainer

### DIFF
--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -88,7 +88,7 @@ class List extends React.Component {
     const {customContainerRender, items} = this.props
 
     return customContainerRender
-      ? customContainerRender(items)
+      ? customContainerRender(this.props)
       : this.renderDefault(items)
   }
 }


### PR DESCRIPTION
Passing props instead of items should be enough to use onSelected method on ListItems.

Note that API Spec is modified from (items) to ({ items }) for customContainerRender method